### PR TITLE
Added wager option to normal and pvp races

### DIFF
--- a/src/main/java/io/github/hielkemaps/racecommand/Commands.java
+++ b/src/main/java/io/github/hielkemaps/racecommand/Commands.java
@@ -16,6 +16,8 @@ import io.github.hielkemaps.racecommand.wrapper.PlayerWrapper;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -344,8 +346,20 @@ public class Commands {
                     if (race.getMinimumWager() > 0) {
                         p.sendMessage("Minimum wager: " + ChatColor.GRAY + race.getMinimumWager());
                     }
+                    if (race.isEvent()) {
+                        Component msg = Component.text("Guaranteed prizes: \n  1st: ")
+                                .append(Component.text(race.getFirstPrize(), NamedTextColor.GOLD, TextDecoration.BOLD))
+                                .append(Component.text("\n  2nd: "))
+                                .append(Component.text(race.getSecondPrize(), NamedTextColor.GRAY, TextDecoration.BOLD))
+                                .append(Component.text("\n  3rd: "))
+                                .append(Component.text(race.getThirdPrize(), TextColor.color(164, 102, 40), TextDecoration.BOLD))
+                                .append(Component.text("\n  4th+: "))
+                                .append(Component.text(race.getFourthPlusPrize(), NamedTextColor.WHITE, TextDecoration.BOLD));
+
+                        p.sendMessage(msg);
+                    }
                     if (race.getTotalPrizePool() > 0) {
-                        p.sendMessage("Prize pool: " + ChatColor.GOLD + race.getTotalPrizePool());
+                        p.sendMessage((race.isEvent() ? "Extra prize pool: " : "Prize pool: ") + ChatColor.GOLD + ChatColor.BOLD + race.getTotalPrizePool());
                     }
                     p.sendMessage("Players:");
 

--- a/src/main/java/io/github/hielkemaps/racecommand/race/Race.java
+++ b/src/main/java/io/github/hielkemaps/racecommand/race/Race.java
@@ -161,19 +161,23 @@ public abstract class Race {
         for (RacePlayer racePlayer : players) {
             actualPrizePool += racePlayer.getTotalWager();
         }
+
+        // When setting the prizes of the race, add the prizes to the already existing prizes
+        // In case the race is an event and has already loaded some prizes
+        // Rather than overriding the event prizes, we should add the prize pool to the existing prizes
         if (actualPrizePool > 0) {
             if (players.size() == 2) {
                 // 1st: 100%
-                setPrizes(actualPrizePool, 0, 0, 0);
+                setPrizes(getFirstPrize() + actualPrizePool, getSecondPrize(), getThirdPrize(), getFourthPlusPrize());
             } else if (players.size() == 3) {
                 // 1st: 70%, 2nd: 30%
                 int firstPrize = (int) Math.round(actualPrizePool * 0.7);
-                setPrizes(firstPrize, actualPrizePool - firstPrize, 0, 0);
+                setPrizes(getFirstPrize() + firstPrize, getSecondPrize() + actualPrizePool - firstPrize, getThirdPrize(), getFourthPlusPrize());
             } else {
                 // 1st: 60%, 2nd: 25%, 3rd: 15%
                 int firstPrize = (int) Math.round(actualPrizePool * 0.6);
                 int secondPrize = (int) Math.round(actualPrizePool * 0.25);
-                setPrizes(firstPrize, secondPrize, actualPrizePool - firstPrize - secondPrize, 0);
+                setPrizes(getFirstPrize() + firstPrize, getSecondPrize() + secondPrize, getThirdPrize() + actualPrizePool - firstPrize - secondPrize, getFourthPlusPrize());
             }
         }
 
@@ -626,10 +630,10 @@ public abstract class Race {
         sendMessage(finishMsg);
 
         if (isEvent || totalPrizePool > 0) {
-            if (place == 1 && prizes[0] > 0) player.givePoints(prizes[0]);
-            if (place == 2 && prizes[1] > 0) player.givePoints(prizes[1]);
-            if (place == 3 && prizes[2] > 0) player.givePoints(prizes[2]);
-            if (place >= 4 && prizes[3] > 0) player.givePoints(prizes[3]);
+            if (place == 1 && prizes[0] > 0) player.givePoints(getFirstPrize());
+            if (place == 2 && prizes[1] > 0) player.givePoints(getSecondPrize());
+            if (place == 3 && prizes[2] > 0) player.givePoints(getThirdPrize());
+            if (place >= 4 && prizes[3] > 0) player.givePoints(getFourthPlusPrize());
         }
     }
 
@@ -670,5 +674,21 @@ public abstract class Race {
         prizes[1] = second;
         prizes[2] = third;
         prizes[3] = fourth;
+    }
+
+    public int getFirstPrize() {
+        return prizes[0];
+    }
+
+    public int getSecondPrize() {
+        return prizes[1];
+    }
+
+    public int getThirdPrize() {
+        return prizes[2];
+    }
+
+    public int getFourthPlusPrize() {
+        return prizes[3];
     }
 }

--- a/src/main/java/io/github/hielkemaps/racecommand/wrapper/PlayerWrapper.java
+++ b/src/main/java/io/github/hielkemaps/racecommand/wrapper/PlayerWrapper.java
@@ -15,6 +15,7 @@ import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.title.Title;
+import org.black_ixx.playerpoints.PlayerPoints;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
@@ -284,5 +285,13 @@ public class PlayerWrapper {
 
     public void showAbilities() {
         abilities.forEach(Ability::show);
+    }
+
+    public int getPlayerPoints() {
+        return PlayerPoints.getInstance().getAPI().look(this.uuid);
+    }
+
+    public void takePlayerPoints(int amount) {
+        PlayerPoints.getInstance().getAPI().take(this.uuid, amount);
     }
 }


### PR DESCRIPTION
Added the ability to put wager on races:
- Race creator can set a minimum wager as an entry prize for any player who joins `/race option wager [minimum]`
- Every player can increase their personal wager (`/race wager increase [amount]`), and decrease the additional wager they put in the race (`/race wager decrease [amount]`)

Changes should be fairly self explanatory, added some comments here and there for more clarity if needed. Most notable changes:
- Added new [option command](https://github.com/JustMe003/RaceCommand/blob/faa2f7e3f20dc3b7a5e17aed4fe5468334d0e22b/src/main/java/io/github/hielkemaps/racecommand/Commands.java#L537) for the race creator. Currently this option can only be used if the race creator is the only one in the race, to avoid players suddenly increasing the minimum wager amount just before starting the race
- Modified the [`/race join [player]` command](https://github.com/JustMe003/RaceCommand/blob/faa2f7e3f20dc3b7a5e17aed4fe5468334d0e22b/src/main/java/io/github/hielkemaps/racecommand/Commands.java#L196). It will now check if the race has a minimum entry wager and if it has, it will show a message to the player to confirm whether they want to join the race or not.
If they confirm to join the race, the same command is runned with an extra, new parameter: `/race join [player] true`.
In both cases, checks are made to see whether the player actually has enough parcoins to pay the entry wager.
- Added new commands for [increasing](https://github.com/JustMe003/RaceCommand/blob/faa2f7e3f20dc3b7a5e17aed4fe5468334d0e22b/src/main/java/io/github/hielkemaps/racecommand/Commands.java#L588) and [decreasing](https://github.com/JustMe003/RaceCommand/blob/faa2f7e3f20dc3b7a5e17aed4fe5468334d0e22b/src/main/java/io/github/hielkemaps/racecommand/Commands.java#L618). This allows any player in the race to increase the prize pool, and retract their additional wager.
- Added fields `wager` and `additionalWager` in `RacePlayer`, along with getters and setters
- Added field `totalPrizePool` to `Race`. This is used to show the prize pool of the race. When the race starts, it re-calculates it just to be sure, and adds the prizes from the prize pool to the existing prizes. This means that players can increase the prizepool of an event without overriding the event prizes
- Added method `getPlayerPoints` and `takePlayerPoints` to `PlayerWrapper`